### PR TITLE
Provide outerspace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 This repository contains software for querying MAST for JWST observations and products, displaying the tables, summarizing them, and downloading the selected products to a local directory.
 
+For installation instructions and documentation, see [our page on Outerspace](https://outerspace.stsci.edu/display/JN/Downloading+NIRCam+images+with+jwst_mast_query). Note that this page requires you to log in, as this tool at the moment is intended only for
+instrument team members.
+


### PR DESCRIPTION
Provide the link to the outerspace page that has installation instructions and documentation. Also add a note that this is intended as a tool only for those working on commissioning at the moment.