### PR TITLE
[do not merge]: Query MAST with new instrument/mode values

### DIFF
--- a/jwst_mast_query/jwst_query.cfg
+++ b/jwst_mast_query/jwst_query.cfg
@@ -1,17 +1,30 @@
 # specify the instrument. The default set in the code is nircam
 instrument: nircam
 
-# Proposal ID and observation numbers
-# obsnums can be specified as a single integer, or a bracketed list
-#propID: 1409
-#obsnums: 3
-#obsnums: [3, 103]
-
-# define the output filename
+# define the output directory
+# outrootdir[/outsubdir][/propID][/obsnumXYZ]
+# propID is the proposal ID number (APT number). Only added if not skip_propID2outsubdir. Note option --skip_propID2outsubdir
+# XYZ is the obsnum. Only added if obsnum2outsubdir==True. Note option --obsnum2outsubdir
 outrootdir: $JWSTDOWNLOAD_OUTDIR
 outsubdir:
 skip_propID2outsubdir: False
+obsnum2outsubdir: True
+# specify list of propID for which obsnum2outsubdir: True
+# This might be useful for propIDs with lots of images: split the products up into subdirs 'obsnumXY'
+propIDs_obsnum2outsubdir: [1409]
+
+# if jpg_separate_subdir is True, then the jpgs are save in separate subdirs 'jpg'. The moves them out of the way
+jpg_separate_subdir: True
+
+# by default, it is checked if the outfile exists. You can skip this with skip_check_if_outfile_exists==True. Note option --skip_check_if_outfile_exists
 skip_check_if_outfile_exists: False
+
+# The script first gets all observations for the given query. Then it queries all products for these
+# observations. For large programs, the query for the products can time out, and in these cases it
+# is better to split up the query into Nobs_per_batch observations per batch. For example, if there are
+# 22 observations, and Nobs_per_batch=4, then there will be 6 batches, 5 batches with 4 observations, and 
+# the last batch with 2. 
+Nobs_per_batch: 2
 
 # specify the list of filetypes to select in the product table,
 # e.g., _uncal.fits or _uncal.jpg.  If only letters, then _ and .fits are added,
@@ -42,9 +55,9 @@ mastcolumns_obsTable: ['proposal_id','dataURL','obsid','obs_id','t_min','t_expti
 # output columns for the tables. Note that the columns for the individual filetypes
 # are automatically added to the obsTable.
 # The defaults set in the code are:
-# outcolumns_productTable=['proposal_id','obsnum','obsID','parent_obsid','obs_id','dataproduct_type','productFilename','filetype','calib_level','size','description']
-# outcolumns_obsTable=['proposal_id','obsnum','obsid','obs_id','t_min','t_exptime','date_min']
-outcolumns_productTable: ['proposal_id','obsnum','obsID','parent_obsid','obs_id','sca','dataproduct_type','filetype','calib_level','size','outfilename','dl_code','dl_str']
+# self.params['outcolumns_productTable']=['proposal_id','obsnum','obsID','parent_obsid','obs_id','dataproduct_type','productFilename','filetype','calib_level','size','description']
+# self.params['outcolumns_obsTable']=['proposal_id','obsnum','obsid','obs_id','t_min','t_exptime','date_min']
+outcolumns_productTable: ['proposal_id','obsnum','obsID','parent_obsid','obs_id','sca','visit','dataproduct_type','filetype','calib_level','size','outfilename','dl_code','dl_str']
 outcolumns_obsTable:     ['proposal_id','obsnum','obsid','obs_id','t_min','t_exptime','date_min']
 
 # The productTable is sorted based on these columns.
@@ -69,14 +82,33 @@ sortcols_obsTable: ['date_min','proposal_id','obsnum']
 # sortcols_summaryTable: ['proposal_id','obsnum']
 sortcols_summaryTable: ['date_start','proposal_id','obsnum']
 
-# Specify the product table properties for the webpage. If thumbnail height is left blank,
-# it will be determined using the thumbnail width and the aspect ratio of the original image.
-# webpage_level12_jpgs lists the filetypes whose thumbnail images will be displayed. Note that
-# pipeline level 3 images are not supported since they are not created by the pipeline.
-webpage_thumbnail_width: 100  # Pixels
-webpage_thumbnail_height:
-webpage_level12_jpgs: ['_uncal.jpg','_dark.jpg','_rate.jpg','_rateints.jpg','_trapsfilled.jpg','_cal.jpg','_crf.jpg']
+#####################################################################################################
+# specify the product table properties for the webpage
+# first the figure box sizes. recommended: 100-150, or don't specify if webpage_mkthumbnails, since then
+# the size of the thumbnails are used by default.
+webpage_tablefigsize_width: 
+webpage_tablefigsize_height: 
 
+# list of filetypes for which jpgs should be shown!
+webpage_level12_jpgs: ['uncal','dark','rate','rateints','cal']
+
+# which fitskeys should be copied to the table
+webpage_fitskeys2table: ['TARG_RA', 'TARG_DEC', 'FILTER', 'PUPIL', 'READPATT', 'NINTS', 'NGROUPS', 'NFRAMES', 'DATE-BEG', 'DATE-END', 'EFFINTTM', 'EFFEXPTM']
+
+# define the output table columns. This can be product table columns as well as the columns defined in 
+# webpage_level12_jpgs and webpage_fitskeys2table
+webpage_cols4table: ['proposal_id', 'obsnum', 'visit', 'obsID', 'parent_obsid', 'sca', 'FILTER', 'PUPIL', 'READPATT', 'uncal', 'dark', 'rate', 'rateints', 'cal', 'TARG_RA', 'TARG_DEC', 'NINTS', 'NGROUPS', 'NFRAMES', 'DATE-BEG', 'DATE-END', 'EFFINTTM', 'EFFEXPTM', 'size', 'obs_id', 'outfilename']
+
+webpage_sortcols: ['proposal_id', 'obsnum', 'visit', 'sca']
+
+# if webpage_mkthumbnails, then a thumbnail jpg is created for each of the jpg products listed in webpage_level12_jpgs
+webpage_mkthumbnails: True
+# redo the thumbnails even if exists if webpage_thumbnails_overwrite is True
+webpage_thumbnails_overwrite: False
+# scale the image down so that it fits the width and height. If only one is specified, then the aspect ratio
+# of the original image is restored
+webpage_thumbnails_width: 120
+webpage_thumbnails_height:
 
 #####################################################################################################
 # The following are other parameters that can be set in the config file, they just need to be uncommented.
@@ -89,4 +121,4 @@ webpage_level12_jpgs: ['_uncal.jpg','_dark.jpg','_rate.jpg','_rateints.jpg','_tr
 # date_select: 2021-05-23+
 
 # save the tables (selected products, obsTable, summary with suffix selprod.txt, obs.txt, summary.txt, respectively) with the specified string as basename
-savetables: ./mast_query_table
+savetables: 

--- a/jwst_mast_query/sortable.js
+++ b/jwst_mast_query/sortable.js
@@ -1,0 +1,284 @@
+/*
+Table sorting script, taken from http://www.kryogenix.org/code/browser/sorttable/ .
+Distributed under the MIT license: http://www.kryogenix.org/code/browser/licence.html .
+
+Adaptation by Joost de Valk ( http://www.joostdevalk.nl/ ) to add alternating row classes as well.
+
+Copyright (c) 1997-2006 Stuart Langridge, Joost de Valk.
+*/
+
+/* Change these values */
+var image_path = "./";
+var image_up = "arrow-up.gif";
+var image_down = "arrow-down.gif";
+var image_none = "arrow-none.gif";
+
+/* Don't change anything below this unless you know what you're doing */
+addEvent(window, "load", sortables_init);
+
+var SORT_COLUMN_INDEX;
+
+function sortables_init() {
+	// Find all tables with class sortable and make them sortable
+	if (!document.getElementsByTagName) return;
+	tbls = document.getElementsByTagName("table");
+	for (ti=0;ti<tbls.length;ti++) {
+		thisTbl = tbls[ti];
+		if (((' '+thisTbl.className+' ').indexOf("sortable") != -1) && (thisTbl.id)) {
+			//initTable(thisTbl.id);
+			ts_makeSortable(thisTbl);
+			//sum_up(thisTbl);
+		}
+	}
+}
+
+function ts_makeSortable(table) {
+	if (table.rows && table.rows.length > 0) {
+		var firstRow = table.rows[0];
+	}
+	if (!firstRow) return;
+	
+	// We have a first row: assume it's the header, and make its contents clickable links
+	for (var i=0;i<firstRow.cells.length;i++) {
+		var cell = firstRow.cells[i];
+		var txt = ts_getInnerText(cell);
+		if (cell.className != "unsortable" && cell.className.indexOf("unsortable") == -1) {
+			cell.innerHTML = '<a href="#" class="sortheader" onclick="ts_resortTable(this);return false;">'+txt+'<span class="sortarrow">&nbsp;&nbsp;<img src="'+ image_path + image_none + '" alt="&darr;"/></span></a>';
+		}
+	}
+	alternate(table);
+}
+
+function ts_getInnerText(el) {
+	if (typeof el == "string") return el;
+	if (typeof el == "undefined") { return el };
+	if (el.innerText) return el.innerText;	//Not needed but it is faster
+	var str = "";
+	
+	var cs = el.childNodes;
+	var l = cs.length;
+	for (var i = 0; i < l; i++) {
+		switch (cs[i].nodeType) {
+			case 1: //ELEMENT_NODE
+				str += ts_getInnerText(cs[i]);
+				break;
+			case 3:	//TEXT_NODE
+				str += cs[i].nodeValue;
+				break;
+		}
+	}
+	return str;
+}
+
+function ts_resortTable(lnk) {
+	// get the span
+	var span;
+	for (var ci=0;ci<lnk.childNodes.length;ci++) {
+		if (lnk.childNodes[ci].tagName && lnk.childNodes[ci].tagName.toLowerCase() == 'span') span = lnk.childNodes[ci];
+	}
+	var spantext = ts_getInnerText(span);
+	var td = lnk.parentNode;
+	var column = td.cellIndex;
+	var table = getParent(td,'TABLE');
+	
+	// Work out a type for the column
+	if (table.rows.length <= 1) return;
+	var itm = ts_getInnerText(table.rows[1].cells[column]);
+	sortfn = ts_sort_caseinsensitive;
+	if (itm.match(/^\d\d[\/-]\d\d[\/-]\d\d\d\d$/)) sortfn = ts_sort_date;
+	if (itm.match(/^\d\d[\/-]\d\d[\/-]\d\d$/)) sortfn = ts_sort_date;
+	if (itm.match(/^[£$€]/)) sortfn = ts_sort_currency;
+	if (itm.match(/^[\d\.]+$/)) sortfn = ts_sort_numeric;
+	SORT_COLUMN_INDEX = column;
+	var firstRow = new Array();
+	var newRows = new Array();
+	for (i=0;i<table.rows[0].length;i++) { 
+		firstRow[i] = table.rows[0][i]; 
+	}
+	for (j=1;j<table.rows.length;j++) { 
+		newRows[j-1] = table.rows[j];
+	}
+
+	newRows.sort(sortfn);
+
+	if (span.getAttribute("sortdir") == 'down') {
+			ARROW = '&nbsp;&nbsp;<img src="'+ image_path + image_up + '" alt="&uarr;"/>';
+			newRows.reverse();
+			span.setAttribute('sortdir','up');
+	} else {
+			ARROW = '&nbsp;&nbsp;<img src="'+ image_path + image_down + '" alt="&darr;"/>';
+			span.setAttribute('sortdir','down');
+	} 
+	
+    // We appendChild rows that already exist to the tbody, so it moves them rather than creating new ones
+    // don't do sortbottom rows
+    for (i=0; i<newRows.length; i++) { 
+		if (!newRows[i].className || (newRows[i].className && (newRows[i].className.indexOf('sortbottom') == -1))) {
+			table.tBodies[0].appendChild(newRows[i]);
+		}
+	}
+    // do sortbottom rows only
+    for (i=0; i<newRows.length; i++) {
+		if (newRows[i].className && (newRows[i].className.indexOf('sortbottom') != -1)) 
+			table.tBodies[0].appendChild(newRows[i]);
+	}
+    
+	// Delete any other arrows there may be showing
+	var allspans = document.getElementsByTagName("span");
+	for (var ci=0;ci<allspans.length;ci++) {
+		if (allspans[ci].className == 'sortarrow') {
+			if (getParent(allspans[ci],"table") == getParent(lnk,"table")) { // in the same table as us?
+				allspans[ci].innerHTML = '&nbsp;&nbsp;<img src="'+ image_path + image_none + '" alt="&darr;"/>';
+			}
+		}
+	}
+			
+	span.innerHTML = ARROW;
+	alternate(table);		
+}
+
+function getParent(el, pTagName) {
+	if (el == null) {
+		return null;
+	} else if (el.nodeType == 1 && el.tagName.toLowerCase() == pTagName.toLowerCase()) {	// Gecko bug, supposed to be uppercase
+		return el;
+	} else {
+		return getParent(el.parentNode, pTagName);
+	}
+}
+function ts_sort_date(a,b) {
+	// y2k notes: two digit years less than 50 are treated as 20XX, greater than 50 are treated as 19XX
+	aa = ts_getInnerText(a.cells[SORT_COLUMN_INDEX]);
+	bb = ts_getInnerText(b.cells[SORT_COLUMN_INDEX]);
+	if (aa.length == 10) {
+			dt1 = aa.substr(6,4)+aa.substr(3,2)+aa.substr(0,2);
+	} else {
+			yr = aa.substr(6,2);
+			if (parseInt(yr) < 50) { 
+				yr = '20'+yr; 
+			} else { 
+				yr = '19'+yr; 
+			}
+			dt1 = yr+aa.substr(3,2)+aa.substr(0,2);
+	}
+	if (bb.length == 10) {
+			dt2 = bb.substr(6,4)+bb.substr(3,2)+bb.substr(0,2);
+	} else {
+			yr = bb.substr(6,2);
+			if (parseInt(yr) < 50) { 
+				yr = '20'+yr; 
+			} else { 
+				yr = '19'+yr; 
+			}
+			dt2 = yr+bb.substr(3,2)+bb.substr(0,2);
+	}
+	if (dt1==dt2) {
+		return 0;
+	}
+	if (dt1<dt2) { 
+		return -1;
+	}
+	return 1;
+}
+
+function ts_sort_currency(a,b) { 
+	aa = ts_getInnerText(a.cells[SORT_COLUMN_INDEX]).replace(/[^0-9.]/g,'');
+	bb = ts_getInnerText(b.cells[SORT_COLUMN_INDEX]).replace(/[^0-9.]/g,'');
+	return parseFloat(aa) - parseFloat(bb);
+}
+
+function ts_sort_numeric(a,b) { 
+	aa = parseFloat(ts_getInnerText(a.cells[SORT_COLUMN_INDEX]));
+	if (isNaN(aa)) {
+		aa = 0;
+	}
+	bb = parseFloat(ts_getInnerText(b.cells[SORT_COLUMN_INDEX])); 
+	if (isNaN(bb)) {
+		bb = 0;
+	}
+	return aa-bb;
+}
+
+function ts_sort_caseinsensitive(a,b) {
+	aa = ts_getInnerText(a.cells[SORT_COLUMN_INDEX]).toLowerCase();
+	bb = ts_getInnerText(b.cells[SORT_COLUMN_INDEX]).toLowerCase();
+	if (aa==bb) {
+		return 0;
+	}
+	if (aa<bb) {
+		return -1;
+	}
+	return 1;
+}
+
+function ts_sort_default(a,b) {
+	aa = ts_getInnerText(a.cells[SORT_COLUMN_INDEX]);
+	bb = ts_getInnerText(b.cells[SORT_COLUMN_INDEX]);
+	if (aa==bb) {
+		return 0;
+	}
+	if (aa<bb) {
+		return -1;
+	}
+	return 1;
+}
+
+function addEvent(elm, evType, fn, useCapture)
+// addEvent and removeEvent
+// cross-browser event handling for IE5+,	NS6 and Mozilla
+// By Scott Andrew
+{
+	if (elm.addEventListener){
+		elm.addEventListener(evType, fn, useCapture);
+		return true;
+	} else if (elm.attachEvent){
+		var r = elm.attachEvent("on"+evType, fn);
+		return r;
+	} else {
+		alert("Handler could not be removed");
+	}
+} 
+
+function replace(s, t, u) {
+  /*
+  **  Replace a token in a string
+  **    s  string to be processed
+  **    t  token to be found and removed
+  **    u  token to be inserted
+  **  returns new String
+  */
+  i = s.indexOf(t);
+  r = "";
+  if (i == -1) return s;
+  r += s.substring(0,i) + u;
+  if ( i + t.length < s.length)
+    r += replace(s.substring(i + t.length, s.length), t, u);
+  return r;
+}
+
+function alternate(table) {
+	// Take object table and get all it's tbodies.
+	var tableBodies = table.getElementsByTagName("tbody");
+	// Loop through these tbodies
+	for (var i = 0; i < tableBodies.length; i++) {
+		// Take the tbody, and get all it's rows
+		var tableRows = tableBodies[i].getElementsByTagName("tr");
+		// Loop through these rows
+		// Start at 1 because we want to leave the heading row untouched
+		for (var j = 1; j < tableRows.length; j++) {
+			// Check if j is even, and apply classes for both possible results
+			if ( (j % 2) == 0  ) {
+				if (tableRows[j].className == 'odd' || !(tableRows[j].className.indexOf('odd') == -1) ) {
+					tableRows[j].className = replace(tableRows[j].className, 'odd', 'even');
+				} else {
+					tableRows[j].className += " even";
+				}
+			} else {
+				if (tableRows[j].className == 'even' || !(tableRows[j].className.indexOf('even') == -1) ) {
+					tableRows[j].className = replace(tableRows[j].className, 'even', 'odd');
+				}
+				tableRows[j].className += " odd";
+			} 
+		}
+	}
+}


### PR DESCRIPTION
Resolves #28 

MAST has recently been updated such that the values the in "instrument" column are no longer e.g. "MIRI" but instead include information on the mode as well (e.g. "MIRI/IMAGE"). Because of this, when querying for only e.g. "MIRI", the results included only files which have not yet been reprocessed in MAST to use the new format. This PR works around this change by making a query using the Observations class in the MAST API. This initial query (which can use a wildcard for its search e.g. "MIRI*") returns a list of the instrument/mode values in the data of interest. This instrument/mode list is then placed into the original query to the Jwst.Filtered database, in order to get back filenames. 


