### PR TITLE
Allow for empty instrument lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+Unreleased
+==========
+
+MAST Query
+----------
+
+Fix a bug that was resulting in jwst_mast_query seraching for files across all instruments in cases where the intial
+instrument mode search returned an empty string. (#38)
+
+
 0.0.2
 =====
 

--- a/jwst_mast_query/jwst_query.py
+++ b/jwst_mast_query/jwst_query.py
@@ -601,7 +601,7 @@ class query_mast:
         # Check to see if the user entered a list of observing modes. If not, we
         # query all modes for the instrument via wildcard
         if self.params['obsmode'][0] is None or len(self.params['obsmode']) == 0:
-            print(f'No obsmode given Querying for all files for {instrument}')
+            print(f'No obsmode given. Querying for all files for {instrument}.')
             inst_list = list(set(Observations.query_criteria(instrument_name=f'{instrument}*',
                                                              t_min=[mjd_min, mjd_max])['instrument_name']))
         else:

--- a/jwst_mast_query/jwst_query.py
+++ b/jwst_mast_query/jwst_query.py
@@ -605,8 +605,6 @@ class query_mast:
             inst_list = list(set(Observations.query_criteria(instrument_name=f'{instrument}*',
                                                              t_min=[mjd_min, mjd_max])['instrument_name']))
         else:
-            print(self.params['obsmode'])
-            stop
             initial_inst_list = [f'{instrument.upper()}/{mode.upper()}' for mode in self.params['obsmode']]
             inst_list = deepcopy(initial_inst_list)
 

--- a/jwst_mast_query/scripts/jwst_download.py
+++ b/jwst_mast_query/scripts/jwst_download.py
@@ -15,7 +15,9 @@ def main():
     # The config file is loaded into self.params, and overwritten with the arguments that are not None
     download.get_arguments(args)
     if download.verbose>2:
-        print('params:', download.params)
+        print('params:')
+        for key, value in download.params.items():
+            print(key, value)
 
     # Use arguments or $API_MAST_TOKEN to login
     download.login(raiseErrorFlag=True)


### PR DESCRIPTION
Tweaks to the observation query such that if the initial query for instrument modes comes back empty, no other queries will be done.

Before this fix, if the mode query came back empty, then jwst_mast_query would move on and query for files using no instrument list, meaning it was searching across all instruments.